### PR TITLE
Fix getRequestPurchaseLink function to pass format argument correctly

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -348,6 +348,7 @@ export class Store {
         invoice.amount,
         invoice.invoiceId,
         Number(StoreFees.REQUEST_PURCHASE),
+        invoice.metadata,
         format
       );
     }


### PR DESCRIPTION
Fixes #1

Corrects the `format` argument passing in the `getRequestPurchaseLink` function.

* Passes the `format` argument as the sixth parameter to `buildUserPaymentLink`.
* Adds the `metadata` field as the fifth parameter to `buildUserPaymentLink`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TheTonpay/tonpay-js-sdk/pull/2?shareId=b225f88b-f0a8-452b-8303-b7f0777493c4).